### PR TITLE
chore : Swagger 세팅 및 Entity 속성 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,11 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
+	implementation ("jakarta.servlet:jakarta.servlet-api:5.0.0")
+
+	// Swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/ArtSeeReal/pro/config/SwaggerConfig.java
+++ b/src/main/java/com/ArtSeeReal/pro/config/SwaggerConfig.java
@@ -1,4 +1,21 @@
 package com.ArtSeeReal.pro.config;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class SwaggerConfig {
+        @Bean
+        public OpenAPI openAPI() {
+                return new OpenAPI()
+                        .info(apiInfo());
+        }
+        private Info apiInfo() {
+                return new Info()
+                        .title("ArtSeeReal API Documentaion")
+                        .description("아트씨리얼의 Swagger UI APIs")
+                        .version("v1.0.0");
+        }
 }

--- a/src/main/java/com/ArtSeeReal/pro/controller/TestController.java
+++ b/src/main/java/com/ArtSeeReal/pro/controller/TestController.java
@@ -1,0 +1,36 @@
+package com.ArtSeeReal.pro.controller;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Swagger Test", description = "This is a test API")
+@RestController
+@RequiredArgsConstructor
+@CrossOrigin
+@RequestMapping("/api")
+public class TestController {
+
+    @Operation(summary = "스웨거 GET 테스트", description = "테스트 api 1 입니다!")
+    @GetMapping("/read")
+    public String getTest(){
+        return "Hello, Swagger!";
+    }
+
+    @Operation(summary = "스웨거 PUT 테스트", description = "테스트 api 2 입니다!")
+    @ApiResponse(responseCode = "200", description = "이럴 경우 성공 응답입니다.")
+    @ApiResponse(responseCode = "400", description = "이럴 경우 실패 응답입니다.")
+    @PutMapping("update")
+    public String putTest(){
+        return "update Complete";
+    }
+
+    @Hidden
+    @GetMapping("/ignore")
+    public String ignore(){
+        return "무시되는 API";
+    }
+}

--- a/src/main/java/com/ArtSeeReal/pro/entity/delete/BoardDelete.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/delete/BoardDelete.java
@@ -28,13 +28,13 @@ public class BoardDelete {
     @Column(length = 64,nullable = false)
     private String userUid;
 
-    @Column(nullable = false, columnDefinition = "0")
+    @Column(nullable = false, columnDefinition = "BIGINT default 0")
     private Long viewCnt;
 
     @Column(length = 128, nullable = false)
     private String title;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/delete/IntroduceDelete.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/delete/IntroduceDelete.java
@@ -26,7 +26,7 @@ public class IntroduceDelete {
     @Column(length = 64,nullable = false)
     private String userUid;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/delete/RequestCommentDelete.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/delete/RequestCommentDelete.java
@@ -29,7 +29,7 @@ public class RequestCommentDelete {
     @Column(length = 64,nullable = false)
     private String postUid;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/delete/RequestDelete.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/delete/RequestDelete.java
@@ -35,7 +35,7 @@ public class RequestDelete {
     @Column(length = 128, nullable = false)
     private String title;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/history/BoardHistory.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/history/BoardHistory.java
@@ -28,7 +28,7 @@ public class BoardHistory {
     @Column(length = 64,nullable = false)
     private String userUid;
 
-    @Column(nullable = false, columnDefinition = "0")
+    @Column(nullable = false, columnDefinition = "BIGINT default 0")
     private Long viewCnt;
 
     @Column(nullable = false)
@@ -37,7 +37,7 @@ public class BoardHistory {
     @Column(length = 128, nullable = false)
     private String oldTitle;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String oldContent;
 
     @Column(nullable = false)
@@ -52,7 +52,7 @@ public class BoardHistory {
     @Column(length = 128, nullable = false)
     private String newTitle;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String newContent;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/history/IntroduceHistory.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/history/IntroduceHistory.java
@@ -26,10 +26,10 @@ public class IntroduceHistory {
     @Column(length = 64,nullable = false)
     private String userUid;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String oldContent;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String newContent;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/history/RequestCommentHistory.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/history/RequestCommentHistory.java
@@ -29,10 +29,10 @@ public class RequestCommentHistory {
     @Column(length = 64,nullable = false)
     private String postUid;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String oldContent;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String newContent;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/history/RequestHistory.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/history/RequestHistory.java
@@ -35,7 +35,7 @@ public class RequestHistory {
     @Column(length = 128, nullable = false)
     private String oldTitle;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String oldContent;
 
     @Column(nullable = false)
@@ -47,7 +47,7 @@ public class RequestHistory {
     @Column(length = 128, nullable = false)
     private String newTitle;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String newContent;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/main/Board.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/main/Board.java
@@ -25,13 +25,13 @@ public class Board {
     @Column(length = 64,nullable = false)
     private String userUid;
 
-    @Column(nullable = false, columnDefinition = "0")
+    @Column(nullable = false, columnDefinition = "BIGINT default 0")
     private Long viewCnt;
 
     @Column(length = 128, nullable = false)
     private String title;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/main/Introduce.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/main/Introduce.java
@@ -22,6 +22,6 @@ public class Introduce {
     @Column(length = 64,nullable = false)
     private String userUid;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 }

--- a/src/main/java/com/ArtSeeReal/pro/entity/main/Request.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/main/Request.java
@@ -32,7 +32,7 @@ public class Request {
     @Column(length = 128, nullable = false)
     private String title;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/ArtSeeReal/pro/entity/main/RequestComment.java
+++ b/src/main/java/com/ArtSeeReal/pro/entity/main/RequestComment.java
@@ -26,7 +26,7 @@ public class RequestComment {
     @Column(length = 64,nullable = false)
     private String postUid;
 
-    @Column(length = 8196, nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,9 +11,26 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+      dialect: org.hibernate.dialect.MySQL8Dialect
     properties:
       hibernate:
         format_sql: true
   mvc:
     path match:
       matching-strategy: ant_path_matcher
+
+logging:
+  level:
+    root: DEBUG
+
+springdoc:
+  packages-to-scan: com.ArtSeeReal.pro.controller
+  swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
+    path: /swagger-ui.html
+    display-query-params-without-oauth2: true
+  api-docs:
+    path: /api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json


### PR DESCRIPTION
1. Swagger 설정 및 테스트 컨트롤러 코드 추가
2. Entity 컬럼 중 테이블 생성 시 오류 발생하는 항목에 대한 columnDefinition 속성값 수정
2-1. viewCnt에 대한 기본값 정의 수정
2-2. 컬럼 최대 사이즈(65,535 bytes) 초과가 발생하지 않도록 content의 데이터타입을 TEXT로 변경